### PR TITLE
send out more exception msg

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -421,11 +421,11 @@ public class JDBCInterpreter extends Interpreter {
 
     } catch (Exception e) {
       logger.error("Cannot run " + sql, e);
-      StringBuilder stringBuilder = new StringBuilder();
-      stringBuilder.append(e.getMessage()).append("\n");
-      stringBuilder.append(e.getClass().toString()).append("\n");
-      stringBuilder.append(StringUtils.join(e.getStackTrace(), "\n"));
-      return new InterpreterResult(Code.ERROR, stringBuilder.toString());
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      PrintStream ps = new PrintStream(baos);
+      e.printStackTrace(ps);
+      String errorMsg = new String(baos.toByteArray(), StandardCharsets.UTF_8);
+      return new InterpreterResult(Code.ERROR, errorMsg);
     }
   }
 


### PR DESCRIPTION
### What is this PR for?

better jdbc error msg make people know the true error clearly.

### What type of PR is it?
Improvement

### Todos

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN/
* Put link here, and add [ZEPPELIN-*Jira number*] in PR title, eg. [ZEPPELIN-533]

### How should this be tested?
Outline the steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?

in sql case, the real error exception stack is hide in e.getCause.getCause. use printStackTrace to receive all the stack trace make people know true reason.

eg:
the raw error msg will send out in a valid sql:

```
class org.apache.hive.service.cli.HiveSQLException
org.apache.hive.service.cli.operation.Operation.toSQLException(Operation.java:368)
org.apache.hive.service.cli.operation.SQLOperation.prepare(SQLOperation.java:129)
org.apache.hive.service.cli.operation.SQLOperation.runInternal(SQLOperation.java:202)
org.apache.hive.service.cli.operation.Operation.run(Operation.java:309)
org.apache.hive.service.cli.session.HiveSessionImpl.executeStatementInternal(HiveSessionImpl.java:464)
org.apache.hive.service.cli.session.HiveSessionImpl.executeStatementAsync(HiveSessionImpl.java:440)
org.apache.hive.service.cli.CLIService.executeStatementAsync(CLIService.java:260)
org.apache.hive.service.cli.thrift.ThriftCLIService.ExecuteStatement(ThriftCLIService.java:507)
org.apache.hive.service.cli.thrift.TCLIService$Processor$ExecuteStatement.getResult(TCLIService.java:1317)
org.apache.hive.service.cli.thrift.TCLIService$Processor$ExecuteStatement.getResult(TCLIService.java:1302)
org.apache.thrift.ProcessFunction.process(ProcessFunction.java:39)
org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:39)
org.apache.hive.service.auth.TSetIpAddressProcessor.process(TSetIpAddressProcessor.java:56)
org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:286)
java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
java.lang.Thread.run(Thread.java:745)
```

after this change. the error msg will be
```
org.apache.hive.service.cli.HiveSQLException: Error while compiling statement: FAILED: SemanticException [Error 10001]: Line 4:4 Table not found 'loan_consumer_application_auto'
	at org.apache.hive.jdbc.Utils.verifySuccess(Utils.java:258)
	at org.apache.hive.jdbc.Utils.verifySuccessWithInfo(Utils.java:244)
	at org.apache.hive.jdbc.HiveStatement.execute(HiveStatement.java:247)
	at org.apache.zeppelin.jdbc.JDBCInterpreter.executeSql(JDBCInterpreter.java:308)
	at org.apache.zeppelin.jdbc.JDBCInterpreter.interpret(JDBCInterpreter.java:413)
	at org.apache.zeppelin.interpreter.LazyOpenInterpreter.interpret(LazyOpenInterpreter.java:94)
	at org.apache.zeppelin.interpreter.remote.RemoteInterpreterServer$InterpretJob.jobRun(RemoteInterpreterServer.java:341)
	at org.apache.zeppelin.scheduler.Job.run(Job.java:176)
	at org.apache.zeppelin.scheduler.ParallelScheduler$JobRunner.run(ParallelScheduler.java:162)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: org.apache.hive.service.cli.HiveSQLException: Error while compiling statement: FAILED: SemanticException [Error 10001]: Line 4:4 Table not found 'loan_consumer_application_auto'
	at org.apache.hive.service.cli.operation.Operation.toSQLException(Operation.java:368)
	at org.apache.hive.service.cli.operation.SQLOperation.prepare(SQLOperation.java:129)
	at org.apache.hive.service.cli.operation.SQLOperation.runInternal(SQLOperation.java:202)
	at org.apache.hive.service.cli.operation.Operation.run(Operation.java:309)
	at org.apache.hive.service.cli.session.HiveSessionImpl.executeStatementInternal(HiveSessionImpl.java:464)
	at org.apache.hive.service.cli.session.HiveSessionImpl.executeStatementAsync(HiveSessionImpl.java:440)
	at org.apache.hive.service.cli.CLIService.executeStatementAsync(CLIService.java:260)
	at org.apache.hive.service.cli.thrift.ThriftCLIService.ExecuteStatement(ThriftCLIService.java:507)
	at org.apache.hive.service.cli.thrift.TCLIService$Processor$ExecuteStatement.getResult(TCLIService.java:1317)
	at org.apache.hive.service.cli.thrift.TCLIService$Processor$ExecuteStatement.getResult(TCLIService.java:1302)
	at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:39)
	at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:39)
	at org.apache.hive.service.auth.TSetIpAddressProcessor.process(TSetIpAddressProcessor.java:56)
	at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:286)
	... 3 more
Caused by: org.apache.hadoop.hive.ql.parse.SemanticException: Line 4:4 Table not found 'loan_consumer_application_auto'
	at org.apache.hadoop.hive.ql.parse.SemanticAnalyzer.getMetaData(SemanticAnalyzer.java:1861)
	at org.apache.hadoop.hive.ql.parse.SemanticAnalyzer.getMetaData(SemanticAnalyzer.java:1554)
	at org.apache.hadoop.hive.ql.parse.SemanticAnalyzer.genResolvedParseTree(SemanticAnalyzer.java:10042)
	at org.apache.hadoop.hive.ql.parse.SemanticAnalyzer.analyzeInternal(SemanticAnalyzer.java:10093)
	at org.apache.hadoop.hive.ql.parse.CalcitePlanner.analyzeInternal(CalcitePlanner.java:229)
	at org.apache.hadoop.hive.ql.parse.BaseSemanticAnalyzer.analyze(BaseSemanticAnalyzer.java:239)
	at org.apache.hadoop.hive.ql.Driver.compile(Driver.java:479)
	at org.apache.hadoop.hive.ql.Driver.compile(Driver.java:319)
	at org.apache.hadoop.hive.ql.Driver.compileInternal(Driver.java:1255)
	at org.apache.hadoop.hive.ql.Driver.compileAndRespond(Driver.java:1245)
	at org.apache.hive.service.cli.operation.SQLOperation.prepare(SQLOperation.java:127)
	... 15 more
Caused by: org.apache.hadoop.hive.ql.parse.SemanticException: Line 4:4 Table not found 'loan_consumer_application_auto'
	at org.apache.hadoop.hive.ql.parse.SemanticAnalyzer.getMetaData(SemanticAnalyzer.java:1604)
	... 25 more
```

then the people will know he use a table that not exist